### PR TITLE
Upgrading version in gemspec file

### DIFF
--- a/mongoid_fulltext.gemspec
+++ b/mongoid_fulltext.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = "mongoid_fulltext"
-  s.version = "0.5.8"
+  s.version = "0.6.0"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Aaron Windsor"]


### PR DESCRIPTION
The gemspec file own the old version 0.5.8. This pull request set the version to 0.6.0.
