### PR TITLE
Upgrading mongoid version dependecy to "~> 3.1.0"

### DIFF
--- a/mongoid_fulltext.gemspec
+++ b/mongoid_fulltext.gemspec
@@ -62,20 +62,20 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<mongoid>, ["~> 3.0.1"])
+      s.add_runtime_dependency(%q<mongoid>, ["~> 3.1.0"])
       s.add_runtime_dependency(%q<unicode_utils>, ["~> 1.0.0"])
       s.add_development_dependency(%q<bundler>, [">= 0"])
       s.add_development_dependency(%q<rspec>, ["~> 2.10.0"])
       s.add_development_dependency(%q<jeweler>, ["~> 1.8.3"])
     else
-      s.add_dependency(%q<mongoid>, ["~> 3.0.1"])
+      s.add_dependency(%q<mongoid>, ["~> 3.1.0"])
       s.add_dependency(%q<unicode_utils>, ["~> 1.0.0"])
       s.add_dependency(%q<bundler>, [">= 0"])
       s.add_dependency(%q<rspec>, ["~> 2.10.0"])
       s.add_dependency(%q<jeweler>, ["~> 1.8.3"])
     end
   else
-    s.add_dependency(%q<mongoid>, ["~> 3.0.1"])
+    s.add_dependency(%q<mongoid>, ["~> 3.1.0"])
     s.add_dependency(%q<unicode_utils>, ["~> 1.0.0"])
     s.add_dependency(%q<bundler>, [">= 0"])
     s.add_dependency(%q<rspec>, ["~> 2.10.0"])


### PR DESCRIPTION
Most of application uses mongoid "~> 3.1.0".
It's probably time to upgrade the main repo.

Thanks.
