### PR TITLE
SCI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,12 @@ sudo: false
 
 matrix:
   include:
+    - rvm: 2.5.0
+      env:
+        - MONGOID_VERSION=7.0
     - rvm: 2.3.1
       env:
         - MONGOID_VERSION=6.0
-      before_script:
-        - bundle exec danger
     - rvm: 2.3.1
       env:
         - MONGOID_VERSION=5.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ matrix:
     - rvm: 2.5.0
       env:
         - MONGOID_VERSION=7.0
+      before_script:
+        - bundle exec danger
     - rvm: 2.3.1
       env:
         - MONGOID_VERSION=6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 0.8.1 (Next)
 
+* [#35](https://github.com/mongoid/mongoid_fulltext/pull/35): Mongoid 7 compatibility - [@tomasc](https://github.com/tomasc).
 * Your contribution here.
 
 ### 0.8.0 (1/19/2017)

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 source 'http://rubygems.org'
 
-case version = ENV['MONGOID_VERSION'] || '6'
+case version = ENV['MONGOID_VERSION'] || '7'
+when /7/
+  gem 'mongoid', '~> 7.0'
 when /6/
   gem 'mongoid', '~> 6.0'
 when /5/

--- a/lib/mongoid/full_text_search.rb
+++ b/lib/mongoid/full_text_search.rb
@@ -143,6 +143,7 @@ module Mongoid::FullTextSearch
       coll = collection.database[index_name]
       cursors = ngrams.map do |ngram|
         query = { 'ngram' => ngram[0] }
+        query.update(document_type_filters)
         query.update(map_query_filters options)
         count = coll.find(query).count
         { ngram: ngram, count: count, query: query }
@@ -296,6 +297,13 @@ module Mongoid::FullTextSearch
 
     private
 
+    # add filter by type according to SCI classes
+    def document_type_filters
+      return {} unless fields['_type'].present?
+      kls = ([self] + descendants).map(&:to_s)
+      { 'document_type' => { "$in" => kls } }
+    end
+
     # Take a list of filters to be mapped so they can update the query
     # used upon the fulltext search of the ngrams
     def map_query_filters(filters)
@@ -350,7 +358,7 @@ module Mongoid::FullTextSearch
       end
       # insert new ngrams in external index
       ngrams.each_pair do |ngram, score|
-        index_document = { 'ngram' => ngram, 'document_id' => _id, 'score' => score, 'class' => self.class.name }
+        index_document = { 'ngram' => ngram, 'document_id' => _id, 'document_type' => model_name.to_s, 'score' => score, 'class' => self.class.name }
         index_document['filter_values'] = filter_values if fulltext_config.key?(:filters)
         if Mongoid::Compatibility::Version.mongoid5_or_newer?
           coll.insert_one(index_document)

--- a/lib/mongoid/full_text_search.rb
+++ b/lib/mongoid/full_text_search.rb
@@ -95,7 +95,7 @@ module Mongoid::FullTextSearch
         all_filter_keys |= keys.find_all { |key| key.starts_with?('filter_values.') }
         next unless keys & correct_keys != correct_keys
         Mongoid.logger.info "Dropping #{idef['name']} [#{keys & correct_keys} <=> #{correct_keys}]" if Mongoid.logger
-        if Mongoid::Compatibility::Version.mongoid5? || Mongoid::Compatibility::Version.mongoid6?
+        if Mongoid::Compatibility::Version.mongoid5_or_newer?
           coll.indexes.drop_one(idef['key'])
         else
           coll.indexes.drop(idef['key'])
@@ -108,14 +108,14 @@ module Mongoid::FullTextSearch
       end
 
       Mongoid.logger.info "Ensuring fts_index on #{coll.name}: #{index_definition}" if Mongoid.logger
-      if Mongoid::Compatibility::Version.mongoid5? || Mongoid::Compatibility::Version.mongoid6?
+      if Mongoid::Compatibility::Version.mongoid5_or_newer?
         coll.indexes.create_one(Hash[index_definition], name: 'fts_index')
       else
         coll.indexes.create(Hash[index_definition], name: 'fts_index')
       end
 
       Mongoid.logger.info "Ensuring document_id index on #{coll.name}" if Mongoid.logger
-      if Mongoid::Compatibility::Version.mongoid5? || Mongoid::Compatibility::Version.mongoid6?
+      if Mongoid::Compatibility::Version.mongoid5_or_newer?
         coll.indexes.create_one('document_id' => 1) # to make removes fast
       else
         coll.indexes.create('document_id' => 1) # to make removes fast
@@ -282,7 +282,7 @@ module Mongoid::FullTextSearch
     def remove_from_ngram_index
       mongoid_fulltext_config.each_pair do |index_name, _fulltext_config|
         coll = collection.database[index_name]
-        if Mongoid::Compatibility::Version.mongoid5? || Mongoid::Compatibility::Version.mongoid6?
+        if Mongoid::Compatibility::Version.mongoid5_or_newer?
           coll.find('class' => name).delete_many
         else
           coll.find('class' => name).remove_all
@@ -328,7 +328,7 @@ module Mongoid::FullTextSearch
 
       # remove existing ngrams from external index
       coll = collection.database[index_name.to_sym]
-      if Mongoid::Compatibility::Version.mongoid5? || Mongoid::Compatibility::Version.mongoid6?
+      if Mongoid::Compatibility::Version.mongoid5_or_newer?
         coll.find('document_id' => _id).delete_many
       else
         coll.find('document_id' => _id).remove_all
@@ -352,7 +352,7 @@ module Mongoid::FullTextSearch
       ngrams.each_pair do |ngram, score|
         index_document = { 'ngram' => ngram, 'document_id' => _id, 'score' => score, 'class' => self.class.name }
         index_document['filter_values'] = filter_values if fulltext_config.key?(:filters)
-        if Mongoid::Compatibility::Version.mongoid5? || Mongoid::Compatibility::Version.mongoid6?
+        if Mongoid::Compatibility::Version.mongoid5_or_newer?
           coll.insert_one(index_document)
         else
           coll.insert(index_document)
@@ -364,7 +364,7 @@ module Mongoid::FullTextSearch
   def remove_from_ngram_index
     mongoid_fulltext_config.each_pair do |index_name, _fulltext_config|
       coll = collection.database[index_name]
-      if Mongoid::Compatibility::Version.mongoid5? || Mongoid::Compatibility::Version.mongoid6?
+      if Mongoid::Compatibility::Version.mongoid5_or_newer?
         coll.find('document_id' => _id).delete_many
       else
         coll.find('document_id' => _id).remove_all

--- a/mongoid_fulltext.gemspec
+++ b/mongoid_fulltext.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/mongoid/mongoid_fulltext'
   s.licenses = ['MIT']
   s.summary = 'Full-text search for the Mongoid ORM, using n-grams extracted from text.'
-  s.add_dependency 'mongoid', '>= 3.0'
+  s.add_dependency 'mongoid', '>= 3.0', '< 8'
   s.add_dependency 'mongoid-compatibility'
   s.add_dependency 'unicode_utils'
 end

--- a/spec/models/my_doc.rb
+++ b/spec/models/my_doc.rb
@@ -1,0 +1,7 @@
+class MyDoc
+  include Mongoid::Document
+  include Mongoid::FullTextSearch
+
+  field :title
+  fulltext_search_in :title
+end

--- a/spec/models/my_further_inherited_doc.rb
+++ b/spec/models/my_further_inherited_doc.rb
@@ -1,0 +1,2 @@
+class MyFurtherInheritedDoc < MyInheritedDoc
+end

--- a/spec/models/my_inherited_doc.rb
+++ b/spec/models/my_inherited_doc.rb
@@ -1,0 +1,2 @@
+class MyInheritedDoc < MyDoc
+end

--- a/spec/mongoid/full_text_search_spec.rb
+++ b/spec/mongoid/full_text_search_spec.rb
@@ -597,7 +597,7 @@ describe Mongoid::FullTextSearch do
     context 'incremental' do
       it 'removes an existing record' do
         coll = Mongoid.default_session['mongoid_fulltext.index_basicartwork_0']
-        if Mongoid::Compatibility::Version.mongoid5? || Mongoid::Compatibility::Version.mongoid6?
+        if Mongoid::Compatibility::Version.mongoid5_or_newer?
           coll.find('document_id' => flowers1._id).delete_many
         else
           coll.find('document_id' => flowers1._id).remove_all

--- a/spec/mongoid/sci_search_spec.rb
+++ b/spec/mongoid/sci_search_spec.rb
@@ -1,0 +1,31 @@
+# coding: utf-8
+require 'spec_helper'
+
+describe Mongoid::FullTextSearch do
+  context 'SCI' do
+    let!(:my_doc) { MyDoc.create!(title: 'My Doc') }
+    let!(:my_inherited_doc) { MyInheritedDoc.create!(title: 'My Inherited Doc') }
+    let!(:my_further_inherited_doc) { MyFurtherInheritedDoc.create!(title: 'My Inherited Doc') }
+
+    context 'root class returns results for subclasses' do
+      let(:result) { MyDoc.fulltext_search("doc") }
+      it { expect(result).to include my_doc }
+      it { expect(result).to include my_inherited_doc }
+      it { expect(result).to include my_further_inherited_doc }
+    end
+
+    context 'child class does not return superclass' do
+      let(:result) { MyInheritedDoc.fulltext_search("doc") }
+      it { expect(result).not_to include my_doc }
+      it { expect(result).to include my_inherited_doc }
+      it { expect(result).to include my_further_inherited_doc }
+    end
+
+    context 'child class does not return superclass' do
+      let(:result) { MyFurtherInheritedDoc.fulltext_search("doc") }
+      it { expect(result).not_to include my_doc }
+      it { expect(result).not_to include my_inherited_doc }
+      it { expect(result).to include my_further_inherited_doc }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,6 @@ RSpec.configure do |c|
   end
   c.before :all do
     Mongoid.logger.level = Logger::INFO
-    Mongo::Logger.logger.level = Logger::INFO if Mongoid::Compatibility::Version.mongoid5? || Mongoid::Compatibility::Version.mongoid6?
+    Mongo::Logger.logger.level = Logger::INFO if Mongoid::Compatibility::Version.mongoid5_or_newer?
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,15 +15,14 @@ Mongoid.configure do |config|
   config.connect_to('mongoid_fulltext_test')
 end
 
+Mongoid.logger.level = Logger::INFO
+Mongo::Logger.logger.level = Logger::INFO if Mongoid::Compatibility::Version.mongoid5_or_newer?
+
 RSpec.configure do |c|
   c.before :each do
     Mongoid.purge!
   end
   c.after :all do
     Mongoid.purge!
-  end
-  c.before :all do
-    Mongoid.logger.level = Logger::INFO
-    Mongo::Logger.logger.level = Logger::INFO if Mongoid::Compatibility::Version.mongoid5_or_newer?
   end
 end

--- a/spec/support/mongoid.rb
+++ b/spec/support/mongoid.rb
@@ -2,4 +2,4 @@ module Mongoid
   def self.default_session
     default_client
   end
-end if Mongoid::Compatibility::Version.mongoid5? || Mongoid::Compatibility::Version.mongoid6?
+end if Mongoid::Compatibility::Version.mongoid5_or_newer?


### PR DESCRIPTION
The search now respects SCI.

From the included spec:

```ruby
class MyDoc
  include Mongoid::Document
  include Mongoid::FullTextSearch

  field :title
  fulltext_search_in :title
end

class MyInheritedDoc < MyDoc
end
```

```ruby
MyDoc.fulltext_search(…) # => will return both MyDoc as well as MyInheritedDoc documents
MyInheritedDoc.fulltext_search(…) # => will return only MyInheritedDoc documents
```