### PR TITLE
Allow for class level ngram updates to not timeout

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -51,6 +51,8 @@ Metrics/AbcSize:
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/BlockLength:
   Max: 622
+  Exclude:
+    - 'spec/mongoid/full_text_search_spec.rb'
 
 # Offense count: 4
 Metrics/CyclomaticComplexity:
@@ -65,6 +67,9 @@ Metrics/MethodLength:
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
   Max: 223
+  Exclude:
+    - 'lib/mongoid/full_text_search.rb'
+
 
 # Offense count: 4
 Metrics/PerceivedComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 0.8.3 (Next)
 
+* [#45](https://github.com/mongoid/mongoid_fulltext/pull/45): Allow for class level ngram updates to not timeout - [@roykolak](https://github.com/roykolak).
 * Your contribution here.
 
 ### 0.8.2 (8/5/2018)

--- a/Gemfile
+++ b/Gemfile
@@ -26,5 +26,5 @@ end
 group :development do
   gem 'mongoid-danger', '~> 0.1.1'
   gem 'rake', '< 11'
-  gem 'rubocop', '~> 0.55'
+  gem 'rubocop', '0.55'
 end

--- a/README.md
+++ b/README.md
@@ -343,6 +343,13 @@ Artwork.update_ngram_index
 Artwork.find(id).update_ngram_index
 ```
 
+If you need to update the index for a large number of documents, using the option below will
+disable your query from timing out:
+
+```ruby
+Artwork.update_ngram_index(timeout: false)
+```
+
 You can remove all or individual instances from the index with the `remove_from_ngram_index`
 method:
 

--- a/lib/mongoid/full_text_search.rb
+++ b/lib/mongoid/full_text_search.rb
@@ -289,8 +289,10 @@ module Mongoid::FullTextSearch
       end
     end
 
-    def update_ngram_index
-      all.each(&:update_ngram_index)
+    def update_ngram_index(options = { timeout: true })
+      items = all
+      items = items.no_timeout if options.key?(:timeout) && !options[:timeout]
+      items.each(&:update_ngram_index)
     end
 
     private

--- a/spec/mongoid/full_text_search_spec.rb
+++ b/spec/mongoid/full_text_search_spec.rb
@@ -634,6 +634,18 @@ describe Mongoid::FullTextSearch do
         BasicArtwork.create_indexes
       end
     end
+
+    context 'using update index options' do
+      it 'will not timeout' do
+        expect(BasicArtwork).to receive_message_chain(:all, :no_timeout).and_return([])
+        BasicArtwork.update_ngram_index(timeout: false)
+      end
+
+      it 'will timeout' do
+        expect(BasicArtwork).to receive_message_chain(:all).and_return([])
+        BasicArtwork.update_ngram_index(timeout: true)
+      end
+    end
   end
 
   context 'batched reindexing' do


### PR DESCRIPTION
When updating the ngrams for a large collection of documents, it's
possible for the cursor to timeout. Therefore add a boolean option,
`timeout` to the class level `update_ngram_index` method. This option
defaults to `true`.

Additionally, lock in the version of rubocop as pulling a newer minor
version (`0.91.1`) resulted in breakage do to new required `yml`
configurations.

Finally exclude `full_text_search_spec.rb` and `full_text_search.rb`
from a few specific rubocop linters to avoid future linting issues
related to file line counts.

Related: #44